### PR TITLE
Update TrustChain

### DIFF
--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
@@ -72,7 +72,7 @@ class DemoApplication : Application() {
     }
 
     private fun createDiscoveryCommunity(): OverlayConfiguration<DiscoveryCommunity> {
-        val randomWalk = RandomWalk.Factory(timeout = 3.0, peers = 20)
+        val randomWalk = RandomWalk.Factory()
         val randomChurn = RandomChurn.Factory()
         val periodicSimilarity = PeriodicSimilarity.Factory()
         return OverlayConfiguration(
@@ -83,10 +83,9 @@ class DemoApplication : Application() {
 
     private fun createTrustChainCommunity(): OverlayConfiguration<TrustChainCommunity> {
         val settings = TrustChainSettings()
-        val driver: SqlDriver = AndroidSqliteDriver(Database.Schema, this, "trustchain.db")
-        val database = Database(driver)
-        val store = TrustChainSQLiteStore(database)
-        val randomWalk = RandomWalk.Factory(timeout = 3.0, peers = 20)
+        val driver = AndroidSqliteDriver(Database.Schema, this, "trustchain.db")
+        val store = TrustChainSQLiteStore(Database(driver))
+        val randomWalk = RandomWalk.Factory()
         return OverlayConfiguration(
             TrustChainCommunity.Factory(settings, store),
             listOf(randomWalk)
@@ -94,7 +93,7 @@ class DemoApplication : Application() {
     }
 
     private fun createDemoCommunity(): OverlayConfiguration<DemoCommunity> {
-        val randomWalk = RandomWalk.Factory(timeout = 3.0, peers = 20)
+        val randomWalk = RandomWalk.Factory()
         return OverlayConfiguration(
             Overlay.Factory(DemoCommunity::class.java),
             listOf(randomWalk)

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
@@ -57,17 +57,17 @@ class DemoApplication : Application() {
                 block: TrustChainBlock,
                 database: TrustChainStore
             ): Boolean {
-                return block.transaction["message"] != null
+                return block.transaction["message"] != null || block.isAgreement
             }
         })
 
         trustchain.addListener(object : BlockListener {
-            override fun shouldSign(block: TrustChainBlock): Boolean {
-                return true
-            }
-
             override fun onBlockReceived(block: TrustChainBlock) {
                 Log.d("TrustChainDemo", "onBlockReceived: ${block.blockId} ${block.transaction}")
+            }
+
+            override fun onSignatureRequest(block: TrustChainBlock) {
+                trustchain.createAgreementBlock(block, mapOf<Any?, Any?>())
             }
         }, "demo_block")
     }

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
@@ -1,73 +1,17 @@
 package nl.tudelft.ipv8.android.demo
 
-import android.util.Log
 import nl.tudelft.ipv8.Address
 import nl.tudelft.ipv8.Community
-import nl.tudelft.ipv8.Peer
-import nl.tudelft.ipv8.messaging.Deserializable
-import nl.tudelft.ipv8.messaging.Packet
-import nl.tudelft.ipv8.messaging.Serializable
-import nl.tudelft.ipv8.messaging.payload.GlobalTimeDistributionPayload
-import nl.tudelft.ipv8.messaging.payload.IntroductionResponsePayload
 import java.util.*
 
 class DemoCommunity : Community() {
     override val serviceId = "02313685c1912a141279f8248fc8db5899c5df5a"
 
-    init {
-        messageHandlers[1] = ::onMessage
-    }
-
-    val discoveredAddresses: MutableSet<Address> = mutableSetOf()
-    val discoveredAddressesIntroduced: MutableMap<Address, Date> = mutableMapOf()
     val discoveredAddressesContacted: MutableMap<Address, Date> = mutableMapOf()
-
-    private fun onMessage(packet: Packet) {
-        val (peer, payload) = packet.getAuthPayload(MyMessage.Companion, cryptoProvider)
-        Log.d("DemoCommunity", peer.mid + ": " + payload.message)
-    }
-
-    fun broadcastGreeting() {
-        for (peer in getPeers()) {
-            val packet = serializePacket(1, listOf(MyMessage("Hello!")))
-            send(peer.address, packet)
-        }
-    }
-
-    override fun onIntroductionResponse(
-        peer: Peer,
-        dist: GlobalTimeDistributionPayload,
-        payload: IntroductionResponsePayload
-    ) {
-        super.onIntroductionResponse(peer, dist, payload)
-
-        Log.d("DemoCommunity", "onIntroductionResponse $payload")
-    }
-
-    override fun discoverAddress(peer: Peer, address: Address, serviceId: String) {
-        super.discoverAddress(peer, address, serviceId)
-
-        discoveredAddresses.add(address)
-        discoveredAddressesIntroduced[address] = Date()
-
-        // TODO: remove old addresses
-    }
 
     override fun walkTo(address: Address) {
         super.walkTo(address)
 
         discoveredAddressesContacted[address] = Date()
-    }
-
-    class MyMessage(val message: String) : Serializable {
-        override fun serialize(): ByteArray {
-            return message.toByteArray()
-        }
-
-        companion object : Deserializable<MyMessage> {
-            override fun deserialize(buffer: ByteArray, offset: Int): Pair<MyMessage, Int> {
-                return Pair(MyMessage(buffer.toString(Charsets.UTF_8)), buffer.size)
-            }
-        }
     }
 }

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/AddressItem.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/AddressItem.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 class AddressItem(
     val address: Address,
-    val discovered: Date,
+    val discovered: Date?,
     val contacted: Date?
 ): Item() {
     override fun areItemsTheSame(other: Item): Boolean {

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/AddressItemRenderer.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/AddressItemRenderer.kt
@@ -21,7 +21,8 @@ class AddressItemRenderer(
         txtLastSent.text = if (lastRequest != null)
             "" + ((Date().time - lastRequest.time) / 1000.0).roundToInt() + " s" else "?"
 
-        txtLastReceived.text = "" + ((Date().time - lastResponse.time) / 1000.0).roundToInt() + " s"
+        txtLastReceived.text = if (lastResponse != null)
+            "" + ((Date().time - lastResponse.time) / 1000.0).roundToInt() + " s" else "?"
 
         txtAvgPing.text = "? ms"
 

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/PeersFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/PeersFragment.kt
@@ -63,27 +63,6 @@ class PeersFragment : BaseFragment() {
 
     private fun loadNetworkInfo() {
         lifecycleScope.launchWhenStarted {
-            val trustchain = getTrustChainCommunity()
-
-            trustchain.registerTransactionValidator("demo_block", object : TransactionValidator {
-                override fun validate(
-                    block: TrustChainBlock,
-                    database: TrustChainStore
-                ): Boolean {
-                    return block.transaction["message"] != null
-                }
-            })
-
-            trustchain.addListener(object : BlockListener {
-                override fun shouldSign(block: TrustChainBlock): Boolean {
-                    return true
-                }
-
-                override fun onBlockReceived(block: TrustChainBlock) {
-                    Log.d("TrustChainDemo", "onBlockReceived: ${block.blockId} ${block.transaction}")
-                }
-            }, "demo_block")
-
             while (isActive) {
                 val overlays = getIpv8().overlays
 
@@ -94,17 +73,14 @@ class PeersFragment : BaseFragment() {
                 val demoCommunity = getDemoCommunity()
                 val peers = demoCommunity.getPeers()
 
-                // Filter only addresses that are not verified yet
-                val discoveredAddresses = demoCommunity.discoveredAddresses.filter { address ->
-                    peers.find { peer -> peer.address == address } == null
-                }
+                val discoveredAddresses = demoCommunity.network
+                    .getWalkableAddresses(demoCommunity.serviceId)
 
                 val peerItems = peers.map { PeerItem(it) }
 
                 val addressItems = discoveredAddresses.map { address ->
-                    val introduced = demoCommunity.discoveredAddressesIntroduced[address]!!
                     val contacted = demoCommunity.discoveredAddressesContacted[address]
-                    AddressItem(address, introduced, contacted)
+                    AddressItem(address, null, contacted)
                 }
 
                 val items = peerItems + addressItems

--- a/doc/OverlayTutorial.md
+++ b/doc/OverlayTutorial.md
@@ -2,6 +2,16 @@
 
 In this tutorial, we will learn how to create a simple overlay network, and send and handle custom messages. Finally, we will configure and start the IPv8 stack, and load our overlay with a discovery strategy, which will allow us to discover other peers in the community using the bootstrap server.
 
+## Project setup
+
+You can check the `demo-android` module to see how to configure an Android app module, initialize IPv8, and interact with the overlays. In essence, Android applications should depend on the `ipv8-android` module, which includes and exposes APIs of `ipv8` module, and defines some Android-specific dependencies and helper classes (e.g. `IPv8Android`).
+
+The dependency is defined with the following line in `build.gradle`:
+
+```
+implementation project(':ipv8-android')
+```
+
 ## Create a community
 
 All communities have to extend an abstract `Community` class, which implements the `Overlay` interface. The only field left for us to define is `serviceId`. This should be an arbitrary 20-byte array represented as a hexadecimal string that uniquely identifies the community.

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -54,7 +54,7 @@ abstract class Community : Overlay {
         network.blacklist.addAll(DEFAULT_ADDRESSES)
 
         job = SupervisorJob()
-        scope = CoroutineScope(Dispatchers.Default + job)
+        scope = CoroutineScope(Dispatchers.Main + job)
     }
 
     override fun unload() {

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -165,22 +165,18 @@ abstract class Community : Overlay {
     internal fun createIntroductionResponse(
         lanSocketAddress: Address,
         socketAddress: Address,
-        identifier: Int,
-        introduction: Peer? = null
+        identifier: Int
     ): ByteArray {
         val globalTime = claimGlobalTime()
         var introductionLan = Address.EMPTY
         var introductionWan = Address.EMPTY
-        var introduced = false
         val other = network.getVerifiedByAddress(socketAddress)
-        var intro = introduction
-        if (intro == null) {
-            intro = getPeerForIntroduction(exclude = other)
-        }
+        val intro = getPeerForIntroduction(exclude = other)
         if (intro != null) {
             /*
-             * If we are introducting a peer on our LAN, we assume our WAN is same as their WAN, and use their LAN port
-             * as a WAN port. Note that this will only work if the port is not translated by NAT.
+             * If we are introducting a peer on our LAN, we assume our WAN is same as their WAN,
+             * and use their LAN port as a WAN port. Note that this will only work if the port is
+             * not translated by NAT.
              */
             if (addressIsLan(intro.address)) {
                 introductionLan = intro.address
@@ -188,7 +184,6 @@ abstract class Community : Overlay {
             } else {
                 introductionWan = intro.address
             }
-            introduced = true
         }
         val payload = IntroductionResponsePayload(
             socketAddress,
@@ -203,7 +198,7 @@ abstract class Community : Overlay {
         val auth = BinMemberAuthenticationPayload(myPeer.publicKey.keyToBin())
         val dist = GlobalTimeDistributionPayload(globalTime)
 
-        if (introduced) {
+        if (intro != null) {
             // TODO: Seems like a bad practice to send a packet in the create method...
             val packet = createPunctureRequest(lanSocketAddress, socketAddress, identifier)
             val punctureRequestAddress = if (introductionLan.isEmpty())
@@ -322,8 +317,8 @@ abstract class Community : Overlay {
         network.discoverServices(peer, listOf(serviceId))
 
         val packet = createIntroductionResponse(
-            payload.destinationAddress,
-            peer.address,
+            payload.sourceLanAddress,
+            payload.sourceWanAddress,
             payload.identifier
         )
 
@@ -337,7 +332,11 @@ abstract class Community : Overlay {
     ) {
         logger.debug("<- $payload")
 
-        myEstimatedWan = payload.destinationAddress
+        // Accept a new WAN address if the sender is not on the same LAN, otherwise they would
+        // just send us our LAN address
+        if (payload.sourceWanAddress.ip != myEstimatedWan.ip) {
+            myEstimatedWan = payload.destinationAddress
+        }
 
         network.addVerifiedPeer(peer)
         network.discoverServices(peer, listOf(serviceId))
@@ -362,7 +361,10 @@ abstract class Community : Overlay {
     }
 
     protected open fun discoverAddress(peer: Peer, address: Address, serviceId: String) {
-        network.discoverAddress(peer, address, serviceId)
+        // Prevent discovering its own address
+        if (address != myEstimatedLan && address != myEstimatedWan) {
+            network.discoverAddress(peer, address, serviceId)
+        }
     }
 
     internal open fun onPuncture(

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockListener.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockListener.kt
@@ -5,12 +5,14 @@ package nl.tudelft.ipv8.attestation.trustchain
  */
 interface BlockListener {
     /**
-     * Method to indicate whether this listener wants a specific block signed or not.
-     */
-    fun shouldSign(block: TrustChainBlock): Boolean
-
-    /**
-     * This method is called when a listener receives a block that matches the BLOCK_CLASS.
+     * It is called when a listener receives a block that matches the registered block type.
      */
     fun onBlockReceived(block: TrustChainBlock)
+
+    /**
+     * It is called whenever a proposal block targeted to use is received and the last
+     * `TrustChainSettings.validationRange` blocks have been received and validated.
+     * `TrustChainCommunity.createAgreementBlock` should be called to create an agreement block.
+     */
+    fun onSignatureRequest(block: TrustChainBlock)
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockListener.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockListener.kt
@@ -8,11 +8,4 @@ interface BlockListener {
      * It is called when a listener receives a block that matches the registered block type.
      */
     fun onBlockReceived(block: TrustChainBlock)
-
-    /**
-     * It is called whenever a proposal block targeted to use is received and the last
-     * `TrustChainSettings.validationRange` blocks have been received and validated.
-     * `TrustChainCommunity.createAgreementBlock` should be called to create an agreement block.
-     */
-    fun onSignatureRequest(block: TrustChainBlock)
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockSigner.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/BlockSigner.kt
@@ -1,0 +1,10 @@
+package nl.tudelft.ipv8.attestation.trustchain
+
+interface BlockSigner {
+    /**
+     * It is called whenever a proposal block targeted to us is received and the last
+     * `TrustChainSettings.validationRange` blocks have been received and validated.
+     * `TrustChainCommunity.createAgreementBlock` should be called to create an agreement block.
+     */
+    fun onSignatureRequest(block: TrustChainBlock)
+}

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
@@ -179,10 +179,6 @@ class TrustChainBlock(
             errors += "Sequence number is prior to genesis"
         }
 
-        if (linkSequenceNumber < GENESIS_SEQ && linkSequenceNumber != UNKNOWN_SEQ) {
-            errors += "Link sequence number not empty and is prior to genesis"
-        }
-
         // TODO: Check signature
 
         if (sequenceNumber == GENESIS_SEQ && !previousHash.contentEquals(GENESIS_HASH)) {

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
@@ -77,9 +77,25 @@ class TrustChainBlock(
 
     val linkedBlockId = linkPublicKey.toHex() + "." + linkSequenceNumber
 
+    /**
+     * Returns whether the block is a genesis block.
+     */
     val isGenesis = sequenceNumber == GENESIS_SEQ && previousHash.contentEquals(GENESIS_HASH)
 
+    /**
+     * Returns whether the block is a self-signed block.
+     */
     val isSelfSigned = publicKey.contentEquals(linkPublicKey)
+
+    /**
+     * Returns whether the block is a proposal block.
+     */
+    val isProposal = linkSequenceNumber == UNKNOWN_SEQ
+
+    /**
+     * Returns whether the block is an agreement block.
+     */
+    val isAgreement = linkSequenceNumber != UNKNOWN_SEQ
 
     val transaction: TrustChainTransaction by lazy {
         try {
@@ -106,10 +122,90 @@ class TrustChainBlock(
      * Validates this block against what is known in the database.
      */
     fun validate(database: TrustChainStore): ValidationResult {
-        // TODO
-        database.getBlockBefore(this)
-        database.getBlockAfter(this)
-        return ValidationResult.Valid
+        val prevBlk = database.getBlockBefore(this)
+        val nextBlk = database.getBlockAfter(this)
+
+        // Initialize the validation result to reflect the achievable validation level.
+        var result = getMaxValidationLevel(prevBlk, nextBlk)
+
+        // Check the block invariant.
+        result = validateBlockInvariant(result)
+
+        // TODO: Check if the linked block as retrieved from our database is the same as the one
+        //  linked by this block. Detect double spend.
+
+        // TODO: Check if the linked block as retrieved from our database is the same as the one
+        //  linked by this block. Detect double countersign fraud.
+
+        // TODO: Check if the chain of blocks is properly hooked up.
+
+        return result
+    }
+
+    /**
+     * Determine the maximum validation level.
+     *
+     * Depending on the blocks we get from the database, we can decide to reduce the validation
+     * level. We must do this prior to flagging any errors. This way we are only ever reducing
+     * the validation level without having to resort to min()/max() every time we set it.
+     */
+    private fun getMaxValidationLevel(
+        prevBlk: TrustChainBlock?,
+        nextBlk: TrustChainBlock?
+    ): ValidationResult {
+        val isPrevGap = prevBlk == null || prevBlk.sequenceNumber != sequenceNumber - 1u
+        val isNextGap = nextBlk == null || nextBlk.sequenceNumber != sequenceNumber + 1u
+
+        return if (prevBlk == null && nextBlk == null && !isGenesis) {
+            ValidationResult.NoInfo
+        } else if (isPrevGap && isNextGap && !isGenesis) {
+            ValidationResult.Partial
+        } else if (isPrevGap && !isGenesis) {
+            ValidationResult.PartialPrevious
+        } else if (isNextGap) {
+            ValidationResult.PartialNext
+        } else {
+            ValidationResult.Valid
+        }
+    }
+
+    /**
+     * Validate that the block is sane.
+     */
+    private fun validateBlockInvariant(prevResult: ValidationResult): ValidationResult {
+        val errors = mutableListOf<String>()
+
+        if (sequenceNumber < GENESIS_SEQ) {
+            errors += "Sequence number is prior to genesis"
+        }
+
+        if (linkSequenceNumber < GENESIS_SEQ && linkSequenceNumber != UNKNOWN_SEQ) {
+            errors += "Link sequence number not empty and is prior to genesis"
+        }
+
+        // TODO: Check signature
+
+        if (sequenceNumber == GENESIS_SEQ && !previousHash.contentEquals(GENESIS_HASH)) {
+            errors += "Sequence number implies previous hash should be Genesis ID"
+        }
+
+        if (sequenceNumber != GENESIS_SEQ && previousHash.contentEquals(GENESIS_HASH)) {
+            errors += "Sequence number implies previous hash should not be Genesis ID"
+        }
+
+        return updateValidationResult(prevResult, errors)
+    }
+
+    private fun updateValidationResult(prevResult: ValidationResult, newErrors: List<String>): ValidationResult {
+        return if (newErrors.isNotEmpty()) {
+            val prevErrors = if (prevResult is ValidationResult.Invalid) {
+                prevResult.errors
+            } else listOf()
+            val errors = prevErrors + newErrors
+            ValidationResult.Invalid(errors)
+        } else {
+            prevResult
+        }
     }
 
     /**

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunity.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunity.kt
@@ -360,7 +360,7 @@ open class TrustChainCommunity(
      * We've received a half block, either because we sent a signed half block to someone or we are
      * crawling.
      */
-    private fun onHalfBlock(sourceAddress: Address, payload: HalfBlockPayload) {
+    internal fun onHalfBlock(sourceAddress: Address, payload: HalfBlockPayload) {
         logger.debug("<- $payload")
 
         val publicKey = cryptoProvider.keyFromPublicBin(payload.publicKey)

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/validation/ValidationResult.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/validation/ValidationResult.kt
@@ -22,7 +22,7 @@ sealed class ValidationResult {
     /**
      * The block does not violate any rules, but there is a gap or no block on the previous block.
      */
-    object PartialPervious : ValidationResult()
+    object PartialPrevious : ValidationResult()
 
     /**
      * There are no blocks (previous or next) to validate against.
@@ -32,5 +32,9 @@ sealed class ValidationResult {
     /**
      * The block violates at least one validation rule.
      */
-    class Invalid(val errors: List<String>) : ValidationResult()
+    class Invalid(val errors: List<String>) : ValidationResult() {
+        override fun toString(): String {
+            return "Invalid(" + errors.joinToString(", ") + ")"
+        }
+    }
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/Network.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/Network.kt
@@ -83,7 +83,7 @@ class Network {
         if (peer.mid in blacklistMids) return
 
         synchronized(graphLock) {
-            // This may just me an address update
+            // This may just be an address update
             for (known in verifiedPeers) {
                 if (known.mid == peer.mid) {
                     known.address = peer.address

--- a/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/RandomWalk.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/RandomWalk.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import nl.tudelft.ipv8.Address
 import nl.tudelft.ipv8.Overlay
 import java.util.*
-import kotlin.random.Random
 
 private val logger = KotlinLogging.logger {}
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/RandomWalk.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/RandomWalk.kt
@@ -60,14 +60,14 @@ class RandomWalk(
             val known = overlay.getWalkableAddresses()
             val available = (known.toSet() - introTimeouts.keys.toSet()).toList()
 
-            // We can get stuck in an infinite loop of unreachable peers if we never contact
-            // the tracker again
-            if (available.isNotEmpty() && Random.nextInt(255) >= resetChance) {
+            // Get a new introduction from a verified peer or a tracker
+            overlay.getNewIntroduction()
+
+            // Walk to a random introduced peer
+            if (available.isNotEmpty()) {
                 val peer = available.random()
                 overlay.walkTo(peer)
                 introTimeouts[peer] = Date()
-            } else {
-                overlay.getNewIntroduction()
             }
 
             this.lastStep = Date()

--- a/ipv8/src/test/java/nl/tudelft/ipv8/BaseCommunityTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/BaseCommunityTest.kt
@@ -3,14 +3,35 @@ package nl.tudelft.ipv8
 import com.goterl.lazycode.lazysodium.LazySodiumJava
 import com.goterl.lazycode.lazysodium.SodiumJava
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.keyvault.PrivateKey
 import nl.tudelft.ipv8.messaging.udp.UdpEndpoint
 import nl.tudelft.ipv8.util.hexToBytes
+import org.junit.After
+import org.junit.Before
 
 private val lazySodium = LazySodiumJava(SodiumJava())
 
+@UseExperimental(ExperimentalCoroutinesApi::class)
 abstract class BaseCommunityTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain() // reset main dispatcher to the original Main dispatcher
+        testDispatcher.cleanupTestCoroutines()
+    }
+
     protected fun getPrivateKey(): PrivateKey {
         val privateKey = "81df0af4c88f274d5228abb894a68906f9e04c902a09c68b9278bf2c7597eaf6"
         val signSeed = "c5c416509d7d262bddfcef421fc5135e0d2bdeb3cb36ae5d0b50321d766f19f2"

--- a/ipv8/src/test/java/nl/tudelft/ipv8/CommunityTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/CommunityTest.kt
@@ -2,6 +2,7 @@ package nl.tudelft.ipv8
 
 import com.goterl.lazycode.lazysodium.LazySodiumJava
 import com.goterl.lazycode.lazysodium.SodiumJava
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -84,15 +85,15 @@ class CommunityTest {
 
     @Test
     fun createIntroductionResponse() {
-        val community = getCommunity()
+        val community = spyk(getCommunity())
 
         community.myEstimatedLan = Address("2.2.3.4", 2234)
         community.myEstimatedWan = Address("3.2.3.4", 3234)
+        every { community.getPeers() } returns listOf(Peer(JavaCryptoProvider.generateKey(), Address("5.2.3.4", 5234)))
         val packet = community.createIntroductionResponse(
             Address("1.2.3.4", 1234),
             Address("1.2.3.4", 1234),
-            2,
-            introduction = Peer(JavaCryptoProvider.generateKey(), Address("5.2.3.4", 5234))
+            2
         )
 
         Assert.assertEquals("000260793bdb9cc0b60c96f88069d78aee327a6241d2f5004a4c69624e61434c504b3a7dc013cef4be5e4e051616a9b3cd9c8d8eb5192f037f3104f6323e43d83a934161ef4f7fe7ea4443da306cd998f830cf8bd543525afd929c83d641c7e9ba0ed300000000000000010102030404d20202030408ba030203040ca200000000000005020304147200000294b144e819f1b3179e8d6117ea7cf7846b4490273999f1bfd2e3c498f9486183be2464cb543003475c5cbff8458ce9e40170d332fad063e238d1dab448098801", packet.toHex())
@@ -106,11 +107,11 @@ class CommunityTest {
 
         community.myEstimatedLan = Address("2.2.3.4", 2234)
         community.myEstimatedWan = Address("3.2.3.4", 3234)
+        every { community.getPeers() } returns listOf(Peer(JavaCryptoProvider.generateKey(), Address("5.2.3.4", 5234)))
         val packet = community.createIntroductionResponse(
             Address("1.2.3.4", 1234),
             Address("1.2.3.4", 1234),
-            2,
-            introduction = Peer(JavaCryptoProvider.generateKey(), Address("5.2.3.4", 5234))
+            2
         )
 
         community.handleIntroductionResponse(Packet(myPeer.address, packet))

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunityTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunityTest.kt
@@ -32,9 +32,9 @@ class TrustChainCommunityTest : BaseCommunityTest() {
         val universalListener = mockk<BlockListener>(relaxed = true)
         val customListener = mockk<BlockListener>(relaxed = true)
         val custom2Listener = mockk<BlockListener>(relaxed = true)
-        community.addListener(universalListener)
-        community.addListener(customListener, "custom")
-        community.addListener(customListener, "custom2")
+        community.addListener(null, universalListener)
+        community.addListener("custom", customListener)
+        community.addListener("custom2", customListener)
 
         val block = TrustChainBlock(
             "custom",
@@ -71,7 +71,7 @@ class TrustChainCommunityTest : BaseCommunityTest() {
         every { community.database.addBlock(any()) } returns Unit
 
         val customListener = mockk<BlockListener>(relaxed = true)
-        community.addListener(customListener, "custom")
+        community.addListener("custom", customListener)
 
         val validator = mockk<TransactionValidator>()
         every { validator.validate(any(), any()) } returns true
@@ -81,9 +81,9 @@ class TrustChainCommunityTest : BaseCommunityTest() {
             "custom",
             "hello".toByteArray(Charsets.US_ASCII),
             getPrivateKey().pub().keyToBin(),
-            0u,
+            GENESIS_SEQ,
             ANY_COUNTERPARTY_PK,
-            0u,
+            UNKNOWN_SEQ,
             GENESIS_HASH,
             EMPTY_SIG,
             Date()


### PR DESCRIPTION
- More accurate WAN estimation in presence of LAN peers
- Request peer introductions more frequently for faster bootstrap
- Basic block validation, crawl previous few blocks before signing
- Breaking API change: `BlockListener` is split into `BlockListener` and `BlockSigner` for more control over agreement block format
- Update tutorial to reflect new changes