### PR TITLE
Network Service Discovery

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,27 +3,27 @@
 This document describes long-term plans for the kotlin-ipv8 project.
 
 ## General
-- tutorial: How to create an overlay
-- tutorial: How to create a TrustChain-based overlay
-- simplify API for IPv8 initialization
+* [x] tutorial: How to create an overlay
+* [x] tutorial: How to create a TrustChain-based overlay
+* [x] simplify API for IPv8 initialization
 
 ## TrustChain
-- block integrity validation
-- py-ipv8 compatible transaction serialization
+* [x] block integrity validation
+* [x] py-ipv8 compatible transaction serialization
 
 ## Peer Discovery
-- LAN discovery
-- Bluetooth LE discovery
+* [x] LAN discovery
+* [ ] Bluetooth LE discovery
 
 ## Connectivity
-- Bluetooth LE for nearby infrastructure-less connectivity
-- relay/proxy community
-- IPv6 support?
+* [ ] Bluetooth LE for nearby infrastructure-less connectivity
+* [ ] relay/proxy community
+* [ ] IPv6 support?
 
 ## DHT
-- DHTCommunity
-- DHTDiscoveryCommunity
+* [ ] DHTCommunity
+* [ ] DHTDiscoveryCommunity
 
 ## Demos
-- TrustChain Explorer
-- PeerChat
+* [x] TrustChain Explorer
+* [ ] PeerChat

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
@@ -1,13 +1,16 @@
 package nl.tudelft.ipv8.android.demo
 
 import android.app.Application
+import android.net.nsd.NsdManager
 import android.util.Log
+import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import nl.tudelft.ipv8.*
 import nl.tudelft.ipv8.android.IPv8Android
 import nl.tudelft.ipv8.android.demo.service.DemoService
 import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
+import nl.tudelft.ipv8.android.peerdiscovery.NetworkServiceDiscovery
 import nl.tudelft.ipv8.attestation.trustchain.*
 import nl.tudelft.ipv8.attestation.trustchain.store.TrustChainSQLiteStore
 import nl.tudelft.ipv8.attestation.trustchain.store.TrustChainStore
@@ -85,17 +88,19 @@ class DemoApplication : Application() {
         val driver = AndroidSqliteDriver(Database.Schema, this, "trustchain.db")
         val store = TrustChainSQLiteStore(Database(driver))
         val randomWalk = RandomWalk.Factory()
+        val nsd = NetworkServiceDiscovery.Factory(getSystemService()!!)
         return OverlayConfiguration(
             TrustChainCommunity.Factory(settings, store),
-            listOf(randomWalk)
+            listOf(randomWalk, nsd)
         )
     }
 
     private fun createDemoCommunity(): OverlayConfiguration<DemoCommunity> {
         val randomWalk = RandomWalk.Factory()
+        val nsd = NetworkServiceDiscovery.Factory(getSystemService()!!)
         return OverlayConfiguration(
             Overlay.Factory(DemoCommunity::class.java),
-            listOf(randomWalk)
+            listOf(randomWalk, nsd)
         )
     }
 

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
@@ -1,7 +1,6 @@
 package nl.tudelft.ipv8.android.demo
 
 import android.app.Application
-import android.net.nsd.NsdManager
 import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoApplication.kt
@@ -87,10 +87,9 @@ class DemoApplication : Application() {
         val driver = AndroidSqliteDriver(Database.Schema, this, "trustchain.db")
         val store = TrustChainSQLiteStore(Database(driver))
         val randomWalk = RandomWalk.Factory()
-        val nsd = NetworkServiceDiscovery.Factory(getSystemService()!!)
         return OverlayConfiguration(
             TrustChainCommunity.Factory(settings, store),
-            listOf(randomWalk, nsd)
+            listOf(randomWalk)
         )
     }
 

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
@@ -2,6 +2,7 @@ package nl.tudelft.ipv8.android.demo
 
 import nl.tudelft.ipv8.Address
 import nl.tudelft.ipv8.Community
+import nl.tudelft.ipv8.android.peerdiscovery.NetworkServiceDiscovery
 import java.util.*
 
 class DemoCommunity : Community() {
@@ -13,5 +14,14 @@ class DemoCommunity : Community() {
         super.walkTo(address)
 
         discoveredAddressesContacted[address] = Date()
+    }
+
+    override fun load() {
+        super.load()
+
+    }
+
+    override fun unload() {
+        super.unload()
     }
 }

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/DemoCommunity.kt
@@ -2,7 +2,6 @@ package nl.tudelft.ipv8.android.demo
 
 import nl.tudelft.ipv8.Address
 import nl.tudelft.ipv8.Community
-import nl.tudelft.ipv8.android.peerdiscovery.NetworkServiceDiscovery
 import java.util.*
 
 class DemoCommunity : Community() {
@@ -18,7 +17,6 @@ class DemoCommunity : Community() {
 
     override fun load() {
         super.load()
-
     }
 
     override fun unload() {

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/users/UsersFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/users/UsersFragment.kt
@@ -1,9 +1,7 @@
 package nl.tudelft.ipv8.android.demo.ui.users
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope

--- a/ipv8-android/build.gradle
+++ b/ipv8-android/build.gradle
@@ -1,6 +1,15 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
+
+ktlint {
+    version = "$ktlint_version"
+    android = true
+    outputToConsole = true
+    ignoreFailures = true
+}
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/IPv8Android.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/IPv8Android.kt
@@ -6,14 +6,11 @@ import android.content.Intent
 import android.net.ConnectivityManager
 import android.os.Build
 import androidx.core.content.getSystemService
-import androidx.lifecycle.ProcessLifecycleOwner
 import nl.tudelft.ipv8.IPv8
 import nl.tudelft.ipv8.IPv8Configuration
 import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
 import nl.tudelft.ipv8.android.messaging.udp.AndroidUdpEndpoint
-import nl.tudelft.ipv8.android.peerdiscovery.NetworkServiceDiscovery
 import nl.tudelft.ipv8.android.service.IPv8Service
-import nl.tudelft.ipv8.keyvault.CryptoProvider
 import nl.tudelft.ipv8.keyvault.PrivateKey
 import nl.tudelft.ipv8.keyvault.defaultCryptoProvider
 import java.net.InetAddress

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/IPv8Android.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/IPv8Android.kt
@@ -11,6 +11,7 @@ import nl.tudelft.ipv8.IPv8
 import nl.tudelft.ipv8.IPv8Configuration
 import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
 import nl.tudelft.ipv8.android.messaging.udp.AndroidUdpEndpoint
+import nl.tudelft.ipv8.android.peerdiscovery.NetworkServiceDiscovery
 import nl.tudelft.ipv8.android.service.IPv8Service
 import nl.tudelft.ipv8.keyvault.CryptoProvider
 import nl.tudelft.ipv8.keyvault.PrivateKey

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/peerdiscovery/NetworkServiceDiscovery.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/peerdiscovery/NetworkServiceDiscovery.kt
@@ -1,0 +1,203 @@
+package nl.tudelft.ipv8.android.peerdiscovery
+
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import mu.KotlinLogging
+import nl.tudelft.ipv8.Address
+import nl.tudelft.ipv8.Overlay
+import nl.tudelft.ipv8.messaging.Packet
+import nl.tudelft.ipv8.messaging.udp.UdpEndpoint
+import nl.tudelft.ipv8.peerdiscovery.strategy.DiscoveryStrategy
+import java.net.InetAddress
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * A strategy to perform network service discovery (NSD) on LAN without using a bootstrap server.
+ */
+class NetworkServiceDiscovery(
+    private val nsdManager: NsdManager,
+    private val overlay: Overlay
+) : DiscoveryStrategy {
+    private var serviceName: String? = null
+
+    private val registrationListener = object : NsdManager.RegistrationListener {
+        override fun onServiceRegistered(serviceInfo: NsdServiceInfo) {
+            // Save the service name. Android may have changed it in order to
+            // resolve a conflict, so update the name you initially requested
+            // with the name Android actually used.
+            logger.info { "Service registered: $serviceInfo" }
+            serviceName = serviceInfo.serviceName
+        }
+
+        override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+            // Registration failed! Put debugging code here to determine why.
+            logger.error { "Service registration failed: $errorCode" }
+        }
+
+        override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {
+            // Service has been unregistered. This only happens when you call
+            // NsdManager.unregisterService() and pass in this listener.
+            logger.info { "Service unregistered: $serviceInfo" }
+        }
+
+        override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+            // Unregistration failed. Put debugging code here to determine why.
+            logger.error { "Service unregistration failed: $errorCode" }
+        }
+    }
+
+    // Instantiate a new DiscoveryListener
+    private val discoveryListener = object : NsdManager.DiscoveryListener {
+
+        // Called as soon as service discovery begins.
+        override fun onDiscoveryStarted(regType: String) {
+            logger.debug { "Service discovery started" }
+        }
+
+        override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+            // A service was found! Do something with it.
+            logger.debug { "Service found: $serviceInfo" }
+
+            if (serviceInfo.serviceType == SERVICE_TYPE) {
+                // This is IPv8 service
+
+                if (serviceInfo.serviceName == serviceName) {
+                    logger.debug { "Found its own service" }
+                    return
+                }
+
+                val serviceId = getServiceId(serviceInfo.serviceName)
+
+                logger.debug { "Service ID: $serviceId" }
+
+                if (serviceId == overlay.serviceId) {
+                    nsdManager.resolveService(serviceInfo, createResolveListener())
+                }
+            }
+        }
+
+        override fun onServiceLost(service: NsdServiceInfo) {
+            // When the network service is no longer available.
+            // Internal bookkeeping code goes here.
+            logger.debug { "Service lost: $service" }
+        }
+
+        override fun onDiscoveryStopped(serviceType: String) {
+            logger.debug("Discovery stopped: $serviceType")
+        }
+
+        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+            logger.error("Discovery failed: $errorCode")
+            nsdManager.stopServiceDiscovery(this)
+        }
+
+        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+            logger.error { "Discovery failed: $errorCode" }
+            nsdManager.stopServiceDiscovery(this)
+        }
+    }
+
+    private fun createResolveListener(): NsdManager.ResolveListener {
+        return object : NsdManager.ResolveListener {
+
+            override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                // Called when the resolve fails. Use the error code to debug.
+                logger.error("Resolve failed: $errorCode")
+            }
+
+            override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+                logger.info("Service resolved: $serviceInfo")
+
+                val peer = overlay.myPeer
+                val address = Address(serviceInfo.host.hostAddress, serviceInfo.port)
+
+                logger.debug { "Discovered address: $address" }
+
+                overlay.network.discoverAddress(peer, address, overlay.serviceId)
+                overlay.walkTo(address)
+            }
+        }
+    }
+
+    private fun registerService(port: Int, serviceId: String) {
+        val serviceInfo = NsdServiceInfo().apply {
+            // The name is subject to change based on conflicts
+            // with other services advertised on the same network.
+            serviceName = serviceId
+            serviceType = SERVICE_TYPE
+            setPort(port)
+        }
+
+        logger.debug { "Registering service info $serviceInfo" }
+
+        nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener)
+    }
+
+    private fun discoverServices() {
+        nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+    }
+
+    private fun unregisterService() {
+        nsdManager.unregisterService(registrationListener)
+    }
+
+    private fun stopServiceDiscovery() {
+        nsdManager.stopServiceDiscovery(discoveryListener)
+    }
+
+    override fun load() {
+        logger.debug { "NetworkServiceDiscovery load" }
+
+        val endpoint = overlay.endpoint
+        if (endpoint is UdpEndpoint) {
+            val socketPort = endpoint.getSocketPort()
+            logger.debug { "Registering service ${overlay.serviceId} on port $socketPort" }
+            registerService(socketPort, overlay.serviceId)
+        } else {
+            logger.error { "Overlay endpoint is not UdpEndpoint" }
+        }
+        discoverServices()
+    }
+
+    override fun takeStep() {
+        // NOOP
+    }
+
+    override fun unload() {
+        logger.debug { "NetworkServiceDiscovery unload" }
+        unregisterService()
+        stopServiceDiscovery()
+    }
+
+    /**
+     * The service ID are the first 40 characters of the service name. Returns null if the service
+     * name name is invalid.
+     */
+    private fun getServiceId(serviceName: String): String? {
+        // Service ID string length is two times its size in bytes as it is hexadecimal encoded
+        val serviceIdLength = Packet.SERVICE_ID_SIZE * 2
+        if (serviceName.length < serviceIdLength) return null
+
+        val serviceId = serviceName.substring(0, serviceIdLength)
+        for (char in serviceId) {
+            if (!char.isDigit() && char !in 'a'..'f') {
+                return null
+            }
+        }
+
+        return serviceId
+    }
+
+    companion object {
+        private const val SERVICE_TYPE = "_ipv8._udp."
+    }
+
+    class Factory(
+        private val nsdManager: NsdManager
+    ) : DiscoveryStrategy.Factory<NetworkServiceDiscovery>() {
+        override fun create(): NetworkServiceDiscovery {
+            return NetworkServiceDiscovery(nsdManager, getOverlay())
+        }
+    }
+}

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/IPv8Service.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/IPv8Service.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.*
 import nl.tudelft.ipv8.*
 import nl.tudelft.ipv8.android.IPv8Android
 import nl.tudelft.ipv8.android.R
+import kotlin.system.exitProcess
 
 open class IPv8Service : Service(), LifecycleObserver {
     private val scope = CoroutineScope(Dispatchers.Default)
@@ -49,6 +50,9 @@ open class IPv8Service : Service(), LifecycleObserver {
             .removeObserver(this)
 
         super.onDestroy()
+
+        // We need to kill the app as IPv8 is started in Application.onCreate
+        exitProcess(0)
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/IPv8Service.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/IPv8Service.kt
@@ -5,10 +5,8 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
-import android.os.Binder
 import android.os.Build
 import android.os.IBinder
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.Lifecycle

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/StopIPv8Receiver.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/StopIPv8Receiver.kt
@@ -4,7 +4,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import nl.tudelft.ipv8.android.IPv8Android
-import kotlin.system.exitProcess
 
 class StopIPv8Receiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/StopIPv8Receiver.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/service/StopIPv8Receiver.kt
@@ -10,6 +10,5 @@ class StopIPv8Receiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val serviceIntent = Intent(context, IPv8Android.serviceClass)
         context.stopService(serviceIntent)
-        exitProcess(0)
     }
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -21,8 +21,8 @@ abstract class Community : Overlay {
     protected val prefix: ByteArray
         get() = ByteArray(0) + 0.toByte() + VERSION + serviceId.hexToBytes()
 
-    var myEstimatedWan: Address = Address.EMPTY
-    var myEstimatedLan: Address = Address.EMPTY
+    override var myEstimatedWan: Address = Address.EMPTY
+    override var myEstimatedLan: Address = Address.EMPTY
 
     private var lastBootstrap: Date? = null
 
@@ -432,7 +432,7 @@ abstract class Community : Overlay {
     }
 
     companion object {
-        val DEFAULT_ADDRESSES = listOf(
+        val DEFAULT_ADDRESSES = listOf<Address>(
             // Dispersy
             // Address("130.161.119.206", 6421),
             // Address("130.161.119.206", 6422),
@@ -449,7 +449,7 @@ abstract class Community : Overlay {
             // Address("81.171.27.194", 6527),
             // Address("81.171.27.194", 6528)
             // py-ipv8 + LibNaCL
-            // Address("131.180.27.161", 6427),
+            Address("131.180.27.161", 6427),
             // kotlin-ipv8
             Address("178.62.16.66", 8090)
         )

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -449,7 +449,7 @@ abstract class Community : Overlay {
             // Address("81.171.27.194", 6527),
             // Address("81.171.27.194", 6528)
             // py-ipv8 + LibNaCL
-            Address("131.180.27.161", 6427),
+            // Address("131.180.27.161", 6427),
             // kotlin-ipv8
             Address("178.62.16.66", 8090)
         )

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Overlay.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Overlay.kt
@@ -17,6 +17,9 @@ interface Overlay : EndpointListener {
     var maxPeers: Int
     var cryptoProvider: CryptoProvider
 
+    var myEstimatedWan: Address
+    var myEstimatedLan: Address
+
     private val globalTime: ULong
         get() = myPeer.lamportTimestamp
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Endpoint.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Endpoint.kt
@@ -7,9 +7,15 @@ private val logger = KotlinLogging.logger {}
 
 abstract class Endpoint {
     private val listeners = mutableListOf<EndpointListener>()
+    private var estimatedLan: Address? = null
 
     fun addListener(listener: EndpointListener) {
         listeners.add(listener)
+
+        val estimatedLan = estimatedLan
+        if (estimatedLan != null) {
+            listener.onEstimatedLanChanged(estimatedLan)
+        }
     }
 
     fun removeListener(listener: EndpointListener) {
@@ -28,6 +34,9 @@ abstract class Endpoint {
 
     protected fun setEstimatedLan(address: Address) {
         logger.info("Estimated LAN address: $address")
+
+        estimatedLan = address
+
         for (listener in listeners) {
             listener.onEstimatedLanChanged(address)
         }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Packet.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Packet.kt
@@ -79,6 +79,14 @@ class Packet(
     }
 
     companion object {
+        /**
+         * The prefix size in bytes.
+         */
         private const val PREFIX_SIZE = 22
+
+        /**
+         * The service ID size in bytes.
+         */
+         const val SERVICE_ID_SIZE = 20
     }
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Packet.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/Packet.kt
@@ -80,13 +80,13 @@ class Packet(
 
     companion object {
         /**
-         * The prefix size in bytes.
-         */
-        private const val PREFIX_SIZE = 22
-
-        /**
          * The service ID size in bytes.
          */
-         const val SERVICE_ID_SIZE = 20
+        const val SERVICE_ID_SIZE = 20
+
+        /**
+         * The prefix size in bytes.
+         */
+        private const val PREFIX_SIZE = SERVICE_ID_SIZE + 2
     }
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/udp/UdpEndpoint.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/udp/UdpEndpoint.kt
@@ -93,7 +93,7 @@ open class UdpEndpoint(
     open fun stopLanEstimation() {
     }
 
-    protected fun getSocketPort(): Int {
+    fun getSocketPort(): Int {
         return socket?.localPort ?: port
     }
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/Network.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/Network.kt
@@ -47,6 +47,7 @@ class Network {
      */
     fun discoverAddress(peer: Peer, address: Address, serviceId: String? = null) {
         if (address in blacklist) {
+            // TODO: Do we need to add the verified peer as it is already added in Community?
             addVerifiedPeer(peer)
             return
         }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/DiscoveryStrategy.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/peerdiscovery/strategy/DiscoveryStrategy.kt
@@ -6,7 +6,24 @@ import nl.tudelft.ipv8.Overlay
  * Strategy for discovering peers in a network.
  */
 interface DiscoveryStrategy {
+    /**
+     * It is called when the IPv8 service is started.
+     */
+    fun load() {
+        // NOOP
+    }
+
+    /**
+     * It is called on every tick in interval defined by [IPv8Configuration.walkerInterval].
+     */
     fun takeStep()
+
+    /**
+     * It is called when the IPv8 service is stopped. Should be used to cleanup any resources.
+     */
+    fun unload() {
+        // NOOP
+    }
 
     abstract class Factory<T : DiscoveryStrategy> {
         private var overlay: Overlay? = null


### PR DESCRIPTION
Add `NetworkServiceDiscovery` strategy to perform DNS-based service discovery (DNS-SD) on LAN without a bootstrap server.