### PR TITLE
Exclude generated files from ktlint

### DIFF
--- a/ipv8/build.gradle
+++ b/ipv8/build.gradle
@@ -29,6 +29,8 @@ ktlint {
     outputToConsole = true
     ignoreFailures = true
     filter {
+        // https://github.com/JLLeitschuh/ktlint-gradle/issues/97
+        exclude {"**/generated/**"}
         // https://github.com/JLLeitschuh/ktlint-gradle/issues/266
         exclude { element -> element.file.path.contains("generated/") }
     }


### PR DESCRIPTION
The current exclusion of generated files did not work, so I added another way to exclude them based on https://github.com/JLLeitschuh/ktlint-gradle/issues/97