### PR TITLE
Make verification more granular

### DIFF
--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunity.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainCommunity.kt
@@ -552,10 +552,9 @@ open class TrustChainCommunity(
 
         if (validationResult !is ValidationResult.Invalid) {
             val validator = getTransactionValidator(block.type)
+
             if (validator != null) {
-                if (!validator.validate(block, database)) {
-                    validationResult = ValidationResult.Invalid(listOf(ValidationErrors.INVALID_TRANSACTION))
-                }
+                validationResult = validator.validate(block, database)
             }
         }
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/validation/TransactionValidator.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/validation/TransactionValidator.kt
@@ -4,5 +4,5 @@ import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
 import nl.tudelft.ipv8.attestation.trustchain.store.TrustChainStore
 
 interface TransactionValidator {
-    fun validate(block: TrustChainBlock, database: TrustChainStore): Boolean
+    fun validate(block: TrustChainBlock, database: TrustChainStore): ValidationResult
 }


### PR DESCRIPTION
Instead of returning a Boolean it should return a ValidationResult. This way you
can crawl for missing blocks by returning PartialPrevious. This is also conform
the python implementation.