### PR TITLE
Replace bintray dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,9 @@ buildscript {
     ext.dokka_version = "0.10.1"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
@@ -31,9 +32,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        maven { url "https://dl.bintray.com/mattskala/maven" }
-        maven { url "https://dl.bintray.com/terl/lazysodium-maven" }
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 
     // Temp fix for issue https://github.com/mockk/mockk/issues/281

--- a/demo-android/build.gradle
+++ b/demo-android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.7.7'
     implementation 'com.github.tony19:logback-android:2.0.0'
 
-    implementation 'com.mattskala:itemadapter:0.3'
+    implementation 'com.github.MattSkala:recyclerview-itemadapter:0.4'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/ipv8-android/build.gradle
+++ b/ipv8-android/build.gradle
@@ -49,7 +49,7 @@ android {
 
 dependencies {
     api (project(':ipv8')) {
-        exclude group: 'com.goterl.lazycode'
+        exclude module: 'lazysodium-java'
     }
 
     // Kotlin
@@ -64,7 +64,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:2.2.0"
 
     // Crypto
-    implementation "com.goterl.lazycode:lazysodium-android:4.1.0@aar"
+    implementation "com.goterl:lazysodium-android:5.0.1@aar"
     implementation 'net.java.dev.jna:jna:5.5.0@aar'
 
     // BLE

--- a/ipv8-android/src/main/java/nl/tudelft/ipv8/android/keyvault/AndroidCryptoProvider.kt
+++ b/ipv8-android/src/main/java/nl/tudelft/ipv8/android/keyvault/AndroidCryptoProvider.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.android.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodiumAndroid
-import com.goterl.lazycode.lazysodium.SodiumAndroid
+import com.goterl.lazysodium.LazySodiumAndroid
+import com.goterl.lazysodium.SodiumAndroid
 import nl.tudelft.ipv8.keyvault.*
 
 private val lazySodium = LazySodiumAndroid(SodiumAndroid())

--- a/ipv8/build.gradle
+++ b/ipv8/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation 'commons-net:commons-net:3.6'
 
     // Crypto
-    implementation "com.goterl.lazycode:lazysodium-java:4.2.4"
+    implementation "com.goterl:lazysodium-java:5.0.1"
 
     // Logging
     implementation 'io.github.microutils:kotlin-logging:1.7.7'

--- a/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/JavaCryptoProvider.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/JavaCryptoProvider.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 
 private val lazySodium = LazySodiumJava(SodiumJava())
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/LibNaClPK.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/LibNaClPK.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodium
-import com.goterl.lazycode.lazysodium.interfaces.Box
+import com.goterl.lazysodium.LazySodium
+import com.goterl.lazysodium.interfaces.Box
 import nl.tudelft.ipv8.util.toHex
 
 class LibNaClPK(

--- a/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/LibNaClSK.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/keyvault/LibNaClSK.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodium
-import com.goterl.lazycode.lazysodium.interfaces.Box
+import com.goterl.lazysodium.LazySodium
+import com.goterl.lazysodium.interfaces.Box
 import nl.tudelft.ipv8.util.toHex
 import kotlin.random.Random
 

--- a/ipv8/src/test/java/nl/tudelft/ipv8/BaseCommunityTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/BaseCommunityTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.Dispatchers

--- a/ipv8/src/test/java/nl/tudelft/ipv8/CommunityTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/CommunityTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk

--- a/ipv8/src/test/java/nl/tudelft/ipv8/TestCommunity.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/TestCommunity.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.keyvault.LibNaClPK
 import nl.tudelft.ipv8.util.hexToBytes
 

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlockTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlockTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import io.mockk.every
 import io.mockk.mockk
 import nl.tudelft.ipv8.attestation.trustchain.payload.HalfBlockPayload

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/CrawlRequestPayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/CrawlRequestPayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes
 import org.junit.Assert

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/CrawlResponsePayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/CrawlResponsePayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_SIG
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockBroadcastPayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockBroadcastPayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_SIG
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPairBroadcastPayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPairBroadcastPayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_SIG
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPairPayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPairPayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_SIG
 import nl.tudelft.ipv8.keyvault.LibNaClSK
 import nl.tudelft.ipv8.util.hexToBytes

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPayloadTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/payload/HalfBlockPayloadTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.payload
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.attestation.trustchain.ANY_COUNTERPARTY_PK
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_SIG
 import nl.tudelft.ipv8.attestation.trustchain.GENESIS_HASH

--- a/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/store/TrustChainStoreTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/attestation/trustchain/store/TrustChainStoreTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.attestation.trustchain.store
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY

--- a/ipv8/src/test/java/nl/tudelft/ipv8/keyvault/LibNaClPKTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/keyvault/LibNaClPKTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.util.hexToBytes
 import nl.tudelft.ipv8.util.toHex
 import org.junit.Assert

--- a/ipv8/src/test/java/nl/tudelft/ipv8/keyvault/LibNaClSKTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/keyvault/LibNaClSKTest.kt
@@ -1,7 +1,7 @@
 package nl.tudelft.ipv8.keyvault
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava
-import com.goterl.lazycode.lazysodium.SodiumJava
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
 import nl.tudelft.ipv8.util.toHex
 import org.junit.Assert
 import org.junit.Test


### PR DESCRIPTION
Bintray repository is not available anymore. 

We fix that in this PR. The dependencies retrieved from bintray are now replaced to use `mavenCentral` and `jitpack`.  Some of the packages in `lazysodium-java` and `lazysodium-android` were changed so the code had to be updated as well.