### PR TITLE
Make compatible with Kotlin 1.5.21 bump

### DIFF
--- a/demo-android/src/test/java/nl/tudelft/trustchain/demo/ExampleUnitTest.kt
+++ b/demo-android/src/test/java/nl/tudelft/trustchain/demo/ExampleUnitTest.kt
@@ -12,6 +12,6 @@ import org.junit.Assert.*
 class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+        assertEquals(4, (2 + 2))
     }
 }

--- a/ipv8-android/src/test/java/nl/tudelft/ipv8/android/ExampleUnitTest.kt
+++ b/ipv8-android/src/test/java/nl/tudelft/ipv8/android/ExampleUnitTest.kt
@@ -12,6 +12,6 @@ import org.junit.Assert.*
 class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+        assertEquals(4, (2 + 2))
     }
 }

--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -342,6 +342,7 @@ abstract class Community : Overlay {
         recipient: Peer? = null
     ): ByteArray {
         var packet = prefix
+        @Suppress("DEPRECATION")
         packet += messageId.toChar().toByte()
 
         if (encrypt && recipient == null) {

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TransactionEncoding.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TransactionEncoding.kt
@@ -59,6 +59,7 @@ object TransactionEncoding {
      */
     fun decode(buffer: ByteArray, offset: Int = 0): Pair<Int, Any?> {
         val version = buffer[offset]
+        @Suppress("DEPRECATION")
         if (version.toChar() == VERSION_A) {
             return decodeValue(buffer, offset + 1)
         } else {
@@ -73,6 +74,7 @@ object TransactionEncoding {
         }
         val count = buffer.copyOfRange(offset, index).toString(Charsets.UTF_8).toInt()
 
+        @Suppress("DEPRECATION")
         return when (val type = buffer[index].toChar().toString()) {
             TYPE_INT -> decodeInt(buffer, index + 1, count)
             TYPE_LONG -> decodeLong(buffer, index + 1, count)

--- a/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/attestation/trustchain/TrustChainBlock.kt
@@ -11,10 +11,13 @@ import java.math.BigInteger
 import java.util.*
 import kotlin.Exception
 
+@Suppress("DEPRECATION")
 val GENESIS_HASH = ByteArray(32) { '0'.toByte() }
 val GENESIS_SEQ = 1u
 val UNKNOWN_SEQ = 0u
+@Suppress("DEPRECATION")
 val EMPTY_SIG = ByteArray(64) { '0'.toByte() }
+@Suppress("DEPRECATION")
 val EMPTY_PK = ByteArray(74) { '0'.toByte() }
 val ANY_COUNTERPARTY_PK = EMPTY_PK
 

--- a/ipv8/src/main/java/nl/tudelft/ipv8/util/HexUtils.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/util/HexUtils.kt
@@ -30,7 +30,9 @@ fun String.hexToBytes(): ByteArray {
     val result = ByteArray(length / 2)
 
     for (i in 0 until length step 2) {
+        @Suppress("DEPRECATION")
         val firstIndex = HEX_CHARS.indexOf(this[i].toLowerCase())
+        @Suppress("DEPRECATION")
         val secondIndex = HEX_CHARS.indexOf(this[i + 1].toLowerCase())
 
         val octet = firstIndex.shl(4).or(secondIndex)

--- a/ipv8/src/test/java/nl/tudelft/ipv8/util/HexUtilsTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/util/HexUtilsTest.kt
@@ -32,6 +32,7 @@ class HexUtilsTest {
     fun hexToBytesToHex() {
         val txid = "d19306e0"
         Assert.assertEquals(txid, txid.hexToBytes().toHex())
+        @Suppress("DEPRECATION")
         Assert.assertEquals(txid, txid.toUpperCase().hexToBytes().toHex())
     }
 


### PR DESCRIPTION
PR in preparation of making it compatible with a Kotlin 1.4.30 > 1.5.21 bump. 

Contains suppress deprecation warnings decorators, due to some char/byte/string methods being deprecated. These however are still supported by Kotlin and only give out warnings. Currently in most modules warnings are set to fail the build (treated as errors) and I assume we do not want to change this, so this is the next best solution. 

Some more info on this:
https://youtrack.jetbrains.com/issue/KT-8087