### PR TITLE
EVA Protocol improvements

### DIFF
--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
@@ -27,6 +27,7 @@ open class EVAProtocol(
     var timeoutInterval: Long = TIMEOUT_INTERVAL,
     var reduceWindowAfterTimeout: Int = REDUCE_WINDOW_AFTER_TIMEOUT,
     var loggingEnabled: Boolean = true,
+    private val maxSimultaneousTransfers: Int = 10
 ) {
     private var scheduled: MutableMap<Key, Queue<ScheduledTransfer>> = mutableMapOf()
     private var incoming: MutableMap<Key, Transfer> = mutableMapOf()
@@ -239,7 +240,7 @@ open class EVAProtocol(
 
         if (loggingEnabled) logger.debug { "EVAPROTOCOL: Sending binary with id '$id', nonce '$nonceValue' for info '$info'." }
 
-        if (outgoing.containsKey(peer.key) || incoming.containsKey(peer.key) || getConnectedPeer(peer.key) == null) {
+        if (outgoing.containsKey(peer.key) || incoming.containsKey(peer.key) || getConnectedPeer(peer.key) == null || isSimultaneouslyServedTransfersLimitExceeded()) {
             if (!isScheduled(peer.key, id)) {
                 val windowSize = getWindowSize(peer.key, id)
                 scheduled.addValue(
@@ -260,6 +261,16 @@ open class EVAProtocol(
         }
 
         startOutgoingTransfer(peer, info, id, data, nonceValue)
+    }
+
+    /**
+     * This asserts an upper limit of simultaneously served peers.
+     * The reason for introducing this parameter is to have a tool for
+     * limiting socket load which could lead to packet loss.
+     */
+    private fun isSimultaneouslyServedTransfersLimitExceeded(): Boolean {
+        val transfersCount = incoming.size + outgoing.size
+        return transfersCount >= maxSimultaneousTransfers
     }
 
     /**
@@ -364,10 +375,10 @@ open class EVAProtocol(
         )
         val transfer = Transfer(TransferType.INCOMING, scheduledTransfer)
 
-        if (loggingEnabled) logger.debug { "EVAPROTOCOL: $transfer"}
+        if (loggingEnabled) logger.debug { "EVAPROTOCOL: $transfer" }
 
         when {
-            payload.dataSize <= 0u ->  {
+            payload.dataSize <= 0u -> {
                 incomingError(
                     peer,
                     transfer,
@@ -429,7 +440,7 @@ open class EVAProtocol(
         if (loggingEnabled) logger.debug { "EVAPROTOCOL: On acknowledgement for window '${payload.ackWindow}'." }
 
         val transfer = outgoing[peer.key] ?: return
-        if (loggingEnabled) logger.debug { "EVAPROTOCOL: Transfer: $transfer"}
+        if (loggingEnabled) logger.debug { "EVAPROTOCOL: Transfer: $transfer" }
 
         if (isStopped(peer.key, transfer.id)) return
 
@@ -437,7 +448,7 @@ open class EVAProtocol(
         transfer.updated = Date().time
 
         if (payload.ackWindow.toInt() > 0) {
-            if (loggingEnabled) logger.debug { "EVAPROTOCOL: UNACKED ${payload.unAckedBlocks.toString(Charsets.UTF_8)}"}
+            if (loggingEnabled) logger.debug { "EVAPROTOCOL: UNACKED ${payload.unAckedBlocks.toString(Charsets.UTF_8)}" }
             transfer.addUnreceivedBlocks(payload.unAckedBlocks)
         }
 
@@ -462,7 +473,7 @@ open class EVAProtocol(
 
             if (data.isEmpty()) return
 
-            if (loggingEnabled) logger.debug { "EVAPROTOCOL: Transmit($blockNumber/${transfer.blockCount-1})" }
+            if (loggingEnabled) logger.debug { "EVAPROTOCOL: Transmit($blockNumber/${transfer.blockCount - 1})" }
 
             val dataPacket = community.createEVAData(peer, blockNumber.toUInt(), transfer.nonce, data)
             send(peer, dataPacket)
@@ -556,7 +567,7 @@ open class EVAProtocol(
             transfer.getUnreceivedBlocksUntil()
         } else byteArrayOf()
 
-        if (loggingEnabled) logger.debug { "EVAPROTOCOL: Acknowledgement for window '${transfer.ackedWindow}' sent to ${peer.mid} with windowSize (${transfer.windowSize}) and nonce ${transfer.nonce}"}
+        if (loggingEnabled) logger.debug { "EVAPROTOCOL: Acknowledgement for window '${transfer.ackedWindow}' sent to ${peer.mid} with windowSize (${transfer.windowSize}) and nonce ${transfer.nonce}" }
 
         val ackPacket = community.createEVAAcknowledgement(
             peer,
@@ -620,6 +631,9 @@ open class EVAProtocol(
      * Send the next scheduled transfer
      */
     private fun sendScheduled() {
+        if (isSimultaneouslyServedTransfersLimitExceeded())
+            return
+
         val idlePeerKeys = scheduled
             .filter { !outgoing.contains(it.key) }
             .map { it.key }
@@ -825,12 +839,12 @@ open class EVAProtocol(
 
     companion object {
         const val MAX_NONCE = Integer.MAX_VALUE.toLong() * 2
-        const val BLOCK_SIZE = 1200
+        const val BLOCK_SIZE = 600
         const val WINDOW_SIZE = 80
         const val BINARY_SIZE_LIMIT = 1024 * 1024 * 250
         const val RETRANSMIT_INTERVAL = 2000L
         const val RETRANSMIT_ATTEMPT_COUNT = 3
-        const val TIMEOUT_INTERVAL = 12000L
+        const val TIMEOUT_INTERVAL = 20000L
         const val REDUCE_WINDOW_AFTER_TIMEOUT = 16
         const val MIN_WINDOW_SIZE = 16
         const val SCHEDULED_SEND_INTERVAL = 5000L

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
@@ -340,12 +340,12 @@ open class EVAProtocol(
         scheduleTerminate(outgoing, peer, transfer)
 
         sendWriteRequest(peer, transfer)
-        retryWriteRequestIfNeeded(transfer, peer)
+        retryWriteRequestIfNeeded(peer, transfer)
     }
 
     private fun retryWriteRequestIfNeeded(
-        transfer: Transfer,
         peer: Peer,
+        transfer: Transfer
     ) {
         scope.launch {
             if (retransmitEnabled) {

--- a/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt
@@ -339,7 +339,7 @@ open class EVAProtocol(
         outgoing[peer.key] = transfer
         scheduleTerminate(outgoing, peer, transfer)
 
-        sendWriteRequest(peer, info, id, nonce, transfer)
+        sendWriteRequest(peer, transfer)
         retryWriteRequestIfNeeded(transfer, peer)
     }
 
@@ -356,7 +356,7 @@ open class EVAProtocol(
 
                     val currentAttempt = "$attempt/$retransmitAttemptCount"
                     if (loggingEnabled) logger.debug { "EVAPROTOCOL: Retrying Write Request. Attempt $currentAttempt for peer: $peer" }
-                    sendWriteRequest(peer, transfer.info, transfer.id, transfer.nonce.toLong(), transfer)
+                    sendWriteRequest(peer, transfer)
                 }
             }
         }
@@ -364,16 +364,13 @@ open class EVAProtocol(
 
     private fun sendWriteRequest(
         peer: Peer,
-        info: String,
-        id: String,
-        nonce: Long,
         transfer: Transfer
     ) {
         val writeRequestPacket = community.createEVAWriteRequest(
             peer,
-            info,
-            id,
-            nonce.toULong(),
+            transfer.info,
+            transfer.id,
+            transfer.nonce,
             transfer.dataSize,
             transfer.blockCount.toUInt(),
             transfer.blockSize.toUInt(),

--- a/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
@@ -469,8 +469,8 @@ class EVAProtocolTest : BaseCommunityTest() {
 
                 method.invoke(
                     evaProtocol,
-                    transfer,
-                    peer
+                    peer,
+                    transfer
                 )
 
                 for (i in 1..evaProtocol.retransmitAttemptCount) {


### PR DESCRIPTION
This PR addresses issues with the EVA protocol dicussed in https://github.com/Tribler/trustchain-superapp/issues/101

The implemented changes are:

- Change of block size from 1200 to 600 and timeout increased to 20s to compensate for the smaller transfers. I'm not entirely sure about the numbers and the only reason I have for setting them this way is that they worked constitently in my experiments, if there is a better method for determining these numbers, please let me know
- Packet Loss fixes and Write Request retries as implemented in https://github.com/Tribler/tribler/pull/6831 (I did not implement the Future and Shutdown functionality since unlike python I'm not aware of a use case for this yet)

The changes worked fine in my local testing using the EVA protocol with Freedom of Computing, please let me know if you require an APK to verify them

@synctext @drew2a 
