### PR TITLE
Migrate to new testing approach and remove temp suppressions 

### DIFF
--- a/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
@@ -2,8 +2,8 @@ package nl.tudelft.ipv8.messaging.eva
 
 import io.mockk.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import nl.tudelft.ipv8.*
 import nl.tudelft.ipv8.keyvault.Key
 import nl.tudelft.ipv8.keyvault.PrivateKey
@@ -354,7 +354,7 @@ class EVAProtocolTest : BaseCommunityTest() {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun startOutgoingTransferRetriesWriteRequestOnFailure() = runBlockingTest {
+    fun startOutgoingTransferRetriesWriteRequestOnFailure() = runBlocking {
         val community = spyk(getCommunity())
         community.load()
 
@@ -371,7 +371,7 @@ class EVAProtocolTest : BaseCommunityTest() {
 
         assertEquals(1, community.getPeers().size)
 
-        val scope = TestCoroutineScope()
+        val scope = TestScope()
         community.evaProtocol = EVAProtocol(community, scope, timeoutInterval = 30000)
 
         community.evaProtocol?.let { evaProtocol ->
@@ -396,8 +396,7 @@ class EVAProtocolTest : BaseCommunityTest() {
                 )
 
                 for (i in 1..evaProtocol.retransmitAttemptCount) {
-                    scope.advanceTimeBy(evaProtocol.retransmitInterval)
-                    delay(1000)
+                    scope.advanceTimeBy(evaProtocol.retransmitInterval + 1000)
                 }
 
                 verify(
@@ -425,13 +424,13 @@ class EVAProtocolTest : BaseCommunityTest() {
 
             }
         }
-
+        scope.cancel()
         community.unload()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun doesNotRetryWriteRequestIfNotNeeded() = runBlockingTest {
+    fun doesNotRetryWriteRequestIfNotNeeded() = runBlocking {
         val community = spyk(getCommunity())
         community.load()
 
@@ -448,7 +447,7 @@ class EVAProtocolTest : BaseCommunityTest() {
 
         assertEquals(1, community.getPeers().size)
 
-        val scope = TestCoroutineScope()
+        val scope = TestScope()
 
         community.evaProtocol = EVAProtocol(community, scope, timeoutInterval = 30000)
 
@@ -486,7 +485,7 @@ class EVAProtocolTest : BaseCommunityTest() {
                 }
             }
         }
-
+        scope.cancel()
         community.unload()
     }
 

--- a/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
@@ -473,8 +473,7 @@ class EVAProtocolTest : BaseCommunityTest() {
                 )
 
                 for (i in 1..evaProtocol.retransmitAttemptCount) {
-                    scope.advanceTimeBy(evaProtocol.retransmitInterval)
-                    delay(1000)
+                    scope.advanceTimeBy(evaProtocol.retransmitInterval + 1000)
                 }
 
                 verify(

--- a/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
+++ b/ipv8/src/test/java/nl/tudelft/ipv8/messaging/eva/EVAProtocolTest.kt
@@ -3,7 +3,6 @@ package nl.tudelft.ipv8.messaging.eva
 import io.mockk.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runBlockingTest
 import nl.tudelft.ipv8.*
 import nl.tudelft.ipv8.keyvault.Key
@@ -353,7 +352,6 @@ class EVAProtocolTest : BaseCommunityTest() {
         community.unload()
     }
 
-    @Suppress("DEPRECATION")
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun startOutgoingTransferRetriesWriteRequestOnFailure() = runBlockingTest {
@@ -373,7 +371,6 @@ class EVAProtocolTest : BaseCommunityTest() {
 
         assertEquals(1, community.getPeers().size)
 
-        @Suppress("DEPRECATION")
         val scope = TestCoroutineScope()
         community.evaProtocol = EVAProtocol(community, scope, timeoutInterval = 30000)
 
@@ -399,7 +396,6 @@ class EVAProtocolTest : BaseCommunityTest() {
                 )
 
                 for (i in 1..evaProtocol.retransmitAttemptCount) {
-                    @Suppress("DEPRECATION")
                     scope.advanceTimeBy(evaProtocol.retransmitInterval)
                     delay(1000)
                 }
@@ -433,7 +429,6 @@ class EVAProtocolTest : BaseCommunityTest() {
         community.unload()
     }
 
-    @Suppress("DEPRECATION")
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun doesNotRetryWriteRequestIfNotNeeded() = runBlockingTest {
@@ -453,7 +448,6 @@ class EVAProtocolTest : BaseCommunityTest() {
 
         assertEquals(1, community.getPeers().size)
 
-        @Suppress("DEPRECATION")
         val scope = TestCoroutineScope()
 
         community.evaProtocol = EVAProtocol(community, scope, timeoutInterval = 30000)
@@ -480,7 +474,6 @@ class EVAProtocolTest : BaseCommunityTest() {
                 )
 
                 for (i in 1..evaProtocol.retransmitAttemptCount) {
-                    @Suppress("DEPRECATION")
                     scope.advanceTimeBy(evaProtocol.retransmitInterval)
                     delay(1000)
                 }


### PR DESCRIPTION
Kotlin migrated to a new method of testing coroutines in 1.6: https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md, this PR patches existing code to follow the new guidelines 