### PR TITLE
Use Default dispatcher instead of Main in Community scope.

### DIFF
--- a/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
+++ b/ipv8/src/main/java/nl/tudelft/ipv8/Community.kt
@@ -70,7 +70,7 @@ abstract class Community : Overlay {
         network.blacklist.addAll(DEFAULT_ADDRESSES)
 
         job = SupervisorJob()
-        scope = CoroutineScope(Dispatchers.Main + job)
+        scope = CoroutineScope(Dispatchers.Default + job)
 
         if (evaProtocolEnabled)
             evaProtocol = EVAProtocol(this, scope)


### PR DESCRIPTION
The coroutineScope in the Community class uses `Dispatchers.Main`. `Dispatchers.Main` is used to run code on the UI thread and should not be used for anything else. 

Code that uses the scope without specifying the Dispatcher when launching a new task (like eva), does not work on a PC, as you need another dependency to access the Main dispatcher. 
https://github.com/Tribler/kotlin-ipv8/blob/f983ed48ad2bb8d9802b1a9106ef44ce63998664/ipv8/src/main/java/nl/tudelft/ipv8/messaging/eva/EVAProtocol.kt#L74 

https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html